### PR TITLE
disallow backticks when not needed

### DIFF
--- a/configs/basic.js
+++ b/configs/basic.js
@@ -315,7 +315,7 @@ module.exports = {
     'quote-props': ['error', 'as-needed'],
     quotes: ['error', 'single', {
       avoidEscape: true,
-      allowTemplateLiterals: true
+      allowTemplateLiterals: false
     }],
     radix: 'error',
     'require-atomic-updates': 'error',


### PR DESCRIPTION
or we do the opposite - enforce backticks over single quotes

but right now in some places I always stumble and think if it's intended or if a `${}` is missing somewhere
