### PR TITLE
enforce empty lines for multiline statements

### DIFF
--- a/configs/basic.js
+++ b/configs/basic.js
@@ -284,10 +284,6 @@ module.exports = {
       next: 'export'
     }, {
       blankLine: 'always',
-      prev: '*',
-      next: 'export'
-    }, {
-      blankLine: 'always',
       prev: 'multiline-block-like',
       next: '*'
     }, {

--- a/configs/basic.js
+++ b/configs/basic.js
@@ -282,6 +282,22 @@ module.exports = {
       blankLine: 'always',
       prev: '*',
       next: 'export'
+    }, {
+      blankLine: 'always',
+      prev: '*',
+      next: 'export'
+    }, {
+      blankLine: 'always',
+      prev: 'multiline-block-like',
+      next: '*'
+    }, {
+      blankLine: 'always',
+      prev: 'multiline-expression',
+      next: '*'
+    }, {
+      blankLine: 'always',
+      prev: 'multiline-let',
+      next: '*'
     }],
     'prefer-arrow-callback': 'off',
     'prefer-const': 'off',

--- a/configs/basic.js
+++ b/configs/basic.js
@@ -288,11 +288,19 @@ module.exports = {
       next: '*'
     }, {
       blankLine: 'always',
+      prev: 'multiline-const',
+      next: '*'
+    }, {
+      blankLine: 'always',
       prev: 'multiline-expression',
       next: '*'
     }, {
       blankLine: 'always',
       prev: 'multiline-let',
+      next: '*'
+    }, {
+      blankLine: 'always',
+      prev: 'multiline-var',
       next: '*'
     }],
     'prefer-arrow-callback': 'off',

--- a/test/import-specifier-newline.test.js
+++ b/test/import-specifier-newline.test.js
@@ -8,8 +8,10 @@ let _ruleTester = new eslint.RuleTester({
     sourceType: 'module'
   }
 });
+
 let _errorMessageallowAllSpecifiersOnSameLine =
   'Import specifiers must go on a new line if they aren\'t all on the same line.';
+
 let _errorMessage = 'Import specifiers must go on a new line.';
 
 _ruleTester.run('import-specifier-newline', rule, {

--- a/test/padding-line-import-multiple.test.js
+++ b/test/padding-line-import-multiple.test.js
@@ -8,6 +8,7 @@ let _ruleTester = new eslint.RuleTester({
     sourceType: 'module'
   }
 });
+
 let _errorMessage = 'Expected an empty line before multiline import statement.';
 
 _ruleTester.run('padding-line-import-multiple', rule, {


### PR DESCRIPTION
Adds a bit more space between complex statements, so it is easier to read code. Tried it out in `atex-dashboard` and it looked well.