### PR TITLE
breaking: prefer single-var destructuring without multiline

### DIFF
--- a/configs/basic.js
+++ b/configs/basic.js
@@ -279,7 +279,7 @@ module.exports = {
       },
       ObjectPattern: {
         multiline: true,
-        minProperties: 1,
+        minProperties: 2, // aka allow 1
         consistent: true
       },
       ImportDeclaration: {

--- a/configs/firecloud.js
+++ b/configs/firecloud.js
@@ -37,7 +37,7 @@ module.exports = {
       },
       ObjectPattern: {
         multiline: true,
-        minProperties: 1,
+        minProperties: 2, // aka allow 1
         consistent: true
       },
       ImportDeclaration: {


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [x]

---

<!-- Describe your contribution -->

had a sparse look at git diffs and it is not that common to have turn a single-var destructuring into multi-var destructuring, which was the main argument (smaller diffs) for requiring multiline even for single-var destructuring