### PR TITLE
allow trivial arrow functions, useful for mapping functions where e.g…

### DIFF
--- a/configs/basic.js
+++ b/configs/basic.js
@@ -37,7 +37,7 @@ module.exports = {
       multiline: true,
       minItems: 1
     }],
-    'arrow-body-style': ['error', 'always'],
+    'arrow-body-style': 'error',
     'arrow-parens': 'error',
     'arrow-spacing': 'error',
     'block-scoped-var': 'error',

--- a/configs/proper-arrows.js
+++ b/configs/proper-arrows.js
@@ -26,11 +26,11 @@ module.exports = {
       ternatry: true,
       chained: true,
       sequence: true,
-      trivial: true
+      trivial: false
     }],
     '@getify/proper-arrows/this': ['error', 'nested', {
       'no-global': true,
-      trivial: true
+      trivial: false
     }]
   }
 };


### PR DESCRIPTION
…. lodash shorthand cannot be used without missing type inference

<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->
